### PR TITLE
Improve PDF reader text selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "markdown-it": "^14.1.0",
     "marked": "^15.0.12",
     "nosleep.js": "^0.12.0",
+    "pdfjs-dist": "^4.6.82",
     "nprogress": "^0.2.0",
     "vue": "^2.7.16",
     "vue-axios": "^2.1.5",

--- a/src/const/kiwiConsts.js
+++ b/src/const/kiwiConsts.js
@@ -181,7 +181,8 @@ export default {
         todo: true,
         youtube: true,
         about: true,
-        aiHistory: true // New: AI History tab enabled by default
+        aiHistory: true, // New: AI History tab enabled by default
+        pdfReader: true
     }),
 
     DB_NAME: 'KIWI_VOCABULARY',

--- a/src/i18n/locales/de.js
+++ b/src/i18n/locales/de.js
@@ -328,6 +328,14 @@ export default {
         aiHistory: 'AI-Verlauf'
     },
 
+    pdf: {
+        selectButton: 'PDF auswählen',
+        changeButton: 'PDF ändern',
+        selectPrompt: 'Select a PDF to begin',
+        invalidType: 'Please choose a valid PDF file.',
+        loadFailed: 'Failed to load the PDF file.'
+    },
+
     about: {
     }
 }

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -74,6 +74,14 @@ export default {
         aiHistory: 'AI History'
     },
 
+    pdf: {
+        selectButton: 'Select PDF',
+        changeButton: 'Change PDF',
+        selectPrompt: 'Select a PDF to begin',
+        invalidType: 'Please choose a valid PDF file.',
+        loadFailed: 'Failed to load the PDF file.'
+    },
+
     // Navigation
     nav: {
         search: 'Search',

--- a/src/i18n/locales/es.js
+++ b/src/i18n/locales/es.js
@@ -295,6 +295,14 @@ export default {
         aiHistory: 'Historial de IA'
     },
 
+    pdf: {
+        selectButton: 'Seleccionar PDF',
+        changeButton: 'Cambiar PDF',
+        selectPrompt: 'Select a PDF to begin',
+        invalidType: 'Please choose a valid PDF file.',
+        loadFailed: 'Failed to load the PDF file.'
+    },
+
     about: {
         // ...existing code...
     }

--- a/src/i18n/locales/fr.js
+++ b/src/i18n/locales/fr.js
@@ -327,6 +327,14 @@ export default {
         aiHistory: 'Historique IA'
     },
 
+    pdf: {
+        selectButton: 'Sélectionner un PDF',
+        changeButton: 'Changer de PDF',
+        selectPrompt: 'Select a PDF to begin',
+        invalidType: 'Please choose a valid PDF file.',
+        loadFailed: 'Failed to load the PDF file.'
+    },
+
     about: {
     }
 }

--- a/src/i18n/locales/ja.js
+++ b/src/i18n/locales/ja.js
@@ -330,6 +330,14 @@ export default {
         aiHistory: 'AI履歴'
     },
 
+    pdf: {
+        selectButton: 'PDF を選択',
+        changeButton: 'PDF を変更',
+        selectPrompt: 'PDF を選択して開始',
+        invalidType: '有効な PDF ファイルを選択してください。',
+        loadFailed: 'PDF ファイルの読み込みに失敗しました。'
+    },
+
     about: {
     }
 }

--- a/src/i18n/locales/ko.js
+++ b/src/i18n/locales/ko.js
@@ -296,6 +296,14 @@ export default {
         aiHistory: 'AI 기록'
     },
 
+    pdf: {
+        selectButton: 'PDF 선택',
+        changeButton: 'PDF 변경',
+        selectPrompt: 'PDF 파일을 선택해 시작하세요',
+        invalidType: '유효한 PDF 파일을 선택해 주세요.',
+        loadFailed: 'PDF 파일을 불러오지 못했습니다.'
+    },
+
     about: {
     }
 }

--- a/src/i18n/locales/th.js
+++ b/src/i18n/locales/th.js
@@ -608,5 +608,13 @@ export default {
         about: 'เกี่ยวกับ',
         vocabularyReview: 'ทบทวนคำศัพท์',
         aiHistory: 'ประวัติ AI'
+    },
+
+    pdf: {
+        selectButton: 'เลือก PDF',
+        changeButton: 'เปลี่ยน PDF',
+        selectPrompt: 'เลือกไฟล์ PDF เพื่อเริ่มต้น',
+        invalidType: 'โปรดเลือกไฟล์ PDF ที่ถูกต้อง',
+        loadFailed: 'ไม่สามารถโหลดไฟล์ PDF ได้'
     }
 }

--- a/src/i18n/locales/zh-CN.js
+++ b/src/i18n/locales/zh-CN.js
@@ -74,6 +74,14 @@ export default {
         aiHistory: 'AI 历史'
     },
 
+    pdf: {
+        selectButton: '选择 PDF 文件',
+        changeButton: '更换 PDF 文件',
+        selectPrompt: '选择一个 PDF 文件开始',
+        invalidType: '请选择有效的 PDF 文件。',
+        loadFailed: 'PDF 文件加载失败。'
+    },
+
     // Navigation
     nav: {
         search: '搜索',

--- a/src/i18n/locales/zh-TW.js
+++ b/src/i18n/locales/zh-TW.js
@@ -340,6 +340,14 @@ export default {
         aiHistory: 'AI 歷史'
     },
 
+    pdf: {
+        selectButton: '選擇 PDF 檔',
+        changeButton: '更換 PDF 檔',
+        selectPrompt: '選擇一個 PDF 檔開始',
+        invalidType: '請選擇有效的 PDF 檔案。',
+        loadFailed: 'PDF 檔案載入失敗。'
+    },
+
     // About section (supplemented)
     about: {
         title: '關於 Kason Tools',

--- a/src/page/index/Index.vue
+++ b/src/page/index/Index.vue
@@ -126,7 +126,7 @@ export default {
     ensureActiveTabValid() {
       const act = this.activeName
       // Tabs governed by enabledTabs
-      const governed = ['starList','todo','youtube','about','aiHistory']
+      const governed = ['starList','todo','youtube','about','aiHistory','pdfReader']
       if (governed.includes(act)) {
         const allowed = !!this.enabledTabs[act]
         // Also consider login-gated tabs
@@ -276,6 +276,12 @@ export default {
           <i class="el-icon-video-camera"></i>
         </span>
         <router-view name="youtube"></router-view>
+      </el-tab-pane>
+      <el-tab-pane name="pdfReader" lazy v-if="enabledTabs.pdfReader">
+        <span slot="label">
+          <i class="el-icon-document"></i>
+        </span>
+        <router-view name="pdfReader" v-if="activeName === 'pdfReader'"></router-view>
       </el-tab-pane>
       <!-- New: AI History tab -->
       <el-tab-pane name="aiHistory" v-if="isLogin && enabledTabs.aiHistory">

--- a/src/page/pdf/PdfReader.vue
+++ b/src/page/pdf/PdfReader.vue
@@ -1,0 +1,520 @@
+<template>
+  <div class="pdf-reader">
+    <div class="pdf-reader__controls">
+      <input
+        ref="fileInput"
+        class="pdf-reader__file-input"
+        type="file"
+        accept="application/pdf"
+        @change="onFileSelected"
+      />
+      <el-button type="primary" icon="el-icon-upload2" @click="triggerFilePicker">
+        {{ pdfLoaded ? $t('pdf.changeButton') : $t('pdf.selectButton') }}
+      </el-button>
+      <span v-if="pdfName" class="pdf-reader__filename">
+        {{ pdfName }}
+      </span>
+      <el-button
+        v-if="pdfLoaded"
+        type="text"
+        icon="el-icon-delete"
+        class="pdf-reader__clear"
+        @click="clearPdf"
+      >
+        {{ $t('common.clear') || 'Clear' }}
+      </el-button>
+    </div>
+
+    <el-alert
+      v-if="errorMessage"
+      type="error"
+      :title="errorMessage"
+      show-icon
+      :closable="false"
+      class="pdf-reader__alert"
+    />
+
+    <div v-if="loading" class="pdf-reader__status">
+      <i class="el-icon-loading"></i>
+      <span>{{ $t('common.loading') || 'Loading PDF…' }}</span>
+    </div>
+
+    <div
+      ref="viewerContainer"
+      class="pdf-reader__viewer"
+      @mouseup="handlePointerSelection"
+      @touchend="handleTouchSelection"
+    >
+      <div ref="viewer" class="pdf-reader__viewer-inner">
+        <div class="pdfViewer"></div>
+      </div>
+      <el-empty
+        v-if="!loading && !pdfLoaded"
+        class="pdf-reader__empty"
+        :description="$t('pdf.selectPrompt')"
+      />
+    </div>
+
+    <transition name="pdf-reader-fade">
+      <div
+        v-if="showSelectionPopup"
+        ref="selectionPopup"
+        class="pdf-selection-popup"
+        :style="popupStyle"
+        @click="navigateToDirectTranslation"
+      >
+        <i class="el-icon-search"></i>
+        <span>"{{ selectedText }}"</span>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf'
+import pdfjsWorker from 'pdfjs-dist/legacy/build/pdf.worker.entry'
+import {
+  EventBus,
+  PDFViewer,
+  PDFLinkService,
+  PDFFindController
+} from 'pdfjs-dist/web/pdf_viewer'
+import 'pdfjs-dist/web/pdf_viewer.css'
+import { getStore } from '@/util/store'
+import kiwiConsts from '@/const/kiwiConsts'
+
+pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorker
+
+export default {
+  name: 'PdfReader',
+  data() {
+    return {
+      loading: false,
+      pdfLoaded: false,
+      pdfName: '',
+      errorMessage: '',
+      selectedText: '',
+      showSelectionPopup: false,
+      popupPosition: {
+        top: 0,
+        left: 0
+      },
+      pdfViewer: null,
+      eventBus: null,
+      linkService: null,
+      findController: null
+    }
+  },
+  computed: {
+    popupStyle() {
+      return {
+        top: `${this.popupPosition.top}px`,
+        left: `${this.popupPosition.left}px`
+      }
+    }
+  },
+  mounted() {
+    document.addEventListener('click', this.handleDocumentClick)
+    window.addEventListener('resize', this.closePopup)
+  },
+  beforeDestroy() {
+    document.removeEventListener('click', this.handleDocumentClick)
+    window.removeEventListener('resize', this.closePopup)
+    this.disposeViewer()
+  },
+  methods: {
+    triggerFilePicker() {
+      if (this.$refs.fileInput) {
+        this.$refs.fileInput.click()
+      }
+    },
+    onFileSelected(event) {
+      const file = event.target.files && event.target.files[0]
+      if (!file) {
+        return
+      }
+
+      this.resetError()
+
+      if (file.type !== 'application/pdf') {
+        this.errorMessage = this.$t('pdf.invalidType') || 'Please choose a valid PDF file.'
+        event.target.value = ''
+        return
+      }
+
+      this.loadPdfFromFile(file)
+      event.target.value = ''
+    },
+    async loadPdfFromFile(file) {
+      this.loading = true
+      this.pdfLoaded = false
+      this.pdfName = file.name
+      this.closePopup()
+      this.clearViewer()
+
+      try {
+        const arrayBuffer = await file.arrayBuffer()
+        await this.renderPdf(arrayBuffer)
+        this.pdfLoaded = true
+      } catch (error) {
+        console.error('[PdfReader] Failed to load PDF:', error)
+        this.errorMessage = this.$t('pdf.loadFailed') || 'Failed to load the PDF file.'
+        this.pdfLoaded = false
+      } finally {
+        this.loading = false
+      }
+    },
+    ensureViewer() {
+      if (this.pdfViewer) {
+        return this.pdfViewer
+      }
+
+      const viewerContainer = this.$refs.viewerContainer
+      const viewer = this.$refs.viewer?.querySelector('.pdfViewer')
+      if (!viewerContainer || !viewer) {
+        return null
+      }
+
+      const eventBus = new EventBus()
+      const linkService = new PDFLinkService({ eventBus })
+      const findController = new PDFFindController({ eventBus, linkService })
+
+      this.pdfViewer = new PDFViewer({
+        container: viewerContainer,
+        viewer,
+        eventBus,
+        linkService,
+        findController,
+        textLayerMode: 1,
+        removePageBorders: true
+      })
+
+      linkService.setViewer(this.pdfViewer)
+
+      eventBus.on('pagesinit', () => {
+        if (this.pdfViewer) {
+          this.pdfViewer.currentScaleValue = 'page-width'
+        }
+      })
+
+      this.eventBus = eventBus
+      this.linkService = linkService
+      this.findController = findController
+
+      return this.pdfViewer
+    },
+    async renderPdf(arrayBuffer) {
+      const typedArray = new Uint8Array(arrayBuffer)
+      const loadingTask = pdfjsLib.getDocument({ data: typedArray })
+      const pdfDocument = await loadingTask.promise
+
+      const viewerInstance = this.ensureViewer()
+      if (!viewerInstance || !this.linkService) {
+        throw new Error('PDF viewer is not available')
+      }
+
+      viewerInstance.setDocument(pdfDocument)
+      this.linkService.setDocument(pdfDocument, null)
+
+      this.$nextTick(() => {
+        if (!viewerInstance._pages?.length) {
+          return
+        }
+        viewerInstance.update()
+      })
+    },
+    handlePointerSelection(event) {
+      this.$nextTick(() => this.processSelection(event))
+    },
+    handleTouchSelection(event) {
+      setTimeout(() => this.processSelection(event), 60)
+    },
+    processSelection(event) {
+      const selection = window.getSelection()
+      if (!selection || selection.isCollapsed) {
+        this.closePopup()
+        return
+      }
+
+      const selectedText = selection.toString().trim()
+      if (!selectedText) {
+        this.closePopup()
+        return
+      }
+
+      if (selection.rangeCount === 0) {
+        this.closePopup()
+        return
+      }
+
+      const range = selection.getRangeAt(0)
+      const viewer = this.$refs.viewer
+
+      if (!viewer || !viewer.contains(range.commonAncestorContainer)) {
+        this.closePopup()
+        return
+      }
+
+      const normalized = selectedText.replace(/\s+/g, ' ').trim()
+      if (!normalized) {
+        this.closePopup()
+        return
+      }
+
+      this.selectedText = normalized
+      let rect = range.getBoundingClientRect()
+
+      if (!rect || (rect.top === 0 && rect.bottom === 0 && rect.left === 0 && rect.right === 0)) {
+        if (event && typeof event.clientX === 'number' && typeof event.clientY === 'number') {
+          rect = {
+            left: event.clientX,
+            right: event.clientX,
+            top: event.clientY,
+            bottom: event.clientY,
+            width: 0,
+            height: 0
+          }
+        }
+      }
+
+      const defaultTop = (rect?.bottom || event?.clientY || 0) + 12
+      const defaultLeft = (rect?.left || event?.clientX || 0) + ((rect?.width || 0) / 2)
+
+      this.popupPosition = {
+        top: defaultTop,
+        left: defaultLeft
+      }
+
+      this.showSelectionPopup = true
+
+      this.$nextTick(() => {
+        const popup = this.$refs.selectionPopup
+        if (!popup) return
+
+        const padding = 12
+        const popupWidth = popup.offsetWidth
+        const popupHeight = popup.offsetHeight
+
+        let left = this.popupPosition.left
+        let top = this.popupPosition.top
+
+        left = Math.min(Math.max(left, padding + popupWidth / 2), window.innerWidth - padding - popupWidth / 2)
+        top = Math.min(Math.max(top, padding + popupHeight), window.innerHeight - padding - popupHeight)
+
+        this.popupPosition = { top, left }
+      })
+    },
+    navigateToDirectTranslation() {
+      const cleaned = this.selectedText ? this.selectedText.trim() : ''
+      if (!cleaned) {
+        this.closePopup()
+        return
+      }
+
+      const encodedText = encodeURIComponent(cleaned)
+      const language = getStore({ name: kiwiConsts.CONFIG_KEY.SELECTED_LANGUAGE })
+        || kiwiConsts.TRANSLATION_LANGUAGE_CODE.Simplified_Chinese
+
+      this.$router.push({
+        path: '/index/tools/aiResponseDetail',
+        query: {
+          active: 'search',
+          selectedMode: kiwiConsts.SEARCH_AI_MODES.DIRECTLY_TRANSLATION.value,
+          language,
+          originalText: encodedText,
+          source: 'pdf',
+          now: Date.now()
+        }
+      })
+
+      this.closePopup()
+    },
+    handleDocumentClick(event) {
+      if (!this.showSelectionPopup) return
+      const popup = this.$refs.selectionPopup
+      if (popup && popup.contains(event.target)) {
+        return
+      }
+
+      if (this.$refs.viewer && this.$refs.viewer.contains(event.target)) {
+        return
+      }
+
+      this.closePopup()
+    },
+    closePopup() {
+      this.showSelectionPopup = false
+      this.selectedText = ''
+      const selection = window.getSelection()
+      if (selection && typeof selection.removeAllRanges === 'function') {
+        try { selection.removeAllRanges() } catch (_) {}
+      }
+    },
+    clearPdf() {
+      this.clearViewer()
+      this.pdfLoaded = false
+      this.pdfName = ''
+      this.resetError()
+      this.closePopup()
+    },
+    clearViewer() {
+      if (this.pdfViewer) {
+        this.pdfViewer.setDocument(null)
+      }
+      const viewer = this.$refs.viewer?.querySelector('.pdfViewer')
+      if (viewer) {
+        viewer.innerHTML = ''
+      }
+    },
+    resetError() {
+      this.errorMessage = ''
+    },
+    disposeViewer() {
+      if (this.pdfViewer?.cleanup) {
+        try {
+          this.pdfViewer.cleanup()
+        } catch (error) {
+          console.warn('[PdfReader] Failed to cleanup viewer', error)
+        }
+      }
+      this.pdfViewer = null
+      this.eventBus = null
+      this.linkService = null
+      this.findController = null
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.pdf-reader {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 16px;
+  box-sizing: border-box;
+
+  &__controls {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  &__file-input {
+    display: none;
+  }
+
+  &__filename {
+    font-size: 14px;
+    color: #606266;
+    max-width: 260px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__clear {
+    margin-left: auto;
+  }
+
+  &__alert {
+    margin-bottom: 12px;
+  }
+
+  &__status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: #606266;
+    margin-bottom: 12px;
+  }
+
+  &__viewer {
+    position: relative;
+    flex: 1;
+    overflow: auto;
+    background: #f5f7fa;
+    border: 1px solid #e4e7ed;
+    border-radius: 8px;
+    padding: 16px;
+    min-height: 360px;
+  }
+}
+
+.pdf-reader__viewer-inner {
+  position: relative;
+  width: 100%;
+  min-height: 100%;
+}
+
+.pdf-reader__empty {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.pdf-selection-popup {
+  position: fixed;
+  z-index: 9999;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: #409eff;
+  color: #fff;
+  border-radius: 20px;
+  box-shadow: 0 6px 18px rgba(64, 158, 255, 0.35);
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    background: #66b1ff;
+    transform: translateY(-1px);
+  }
+}
+
+.pdf-reader-fade-enter-active,
+.pdf-reader-fade-leave-active {
+  transition: opacity 0.15s ease;
+}
+
+.pdf-reader-fade-enter,
+.pdf-reader-fade-leave-to {
+  opacity: 0;
+}
+
+::v-deep(.pdfViewer .page) {
+  position: relative;
+  margin: 0 auto 16px;
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+::v-deep(.pdfViewer .page canvas) {
+  display: block;
+  width: 100% !important;
+  height: auto !important;
+}
+
+@media (max-width: 768px) {
+  .pdf-reader {
+    padding: 12px;
+
+    &__viewer {
+      padding: 12px;
+      min-height: 280px;
+    }
+  }
+
+  .pdf-selection-popup {
+    font-size: 13px;
+    padding: 8px 12px;
+  }
+}
+</style>

--- a/src/router/page/index.js
+++ b/src/router/page/index.js
@@ -12,6 +12,7 @@ import AiCallHistory from '@/page/ai/AiCallHistory.vue' // Import the new AI cal
 import Youtube from '@/page/ai/Youtube.vue'
 import YoutubePlayer from "@/page/ai/YoutubePlayer.vue"; // Import the new component
 import TodoView from '@/page/todo/TodoView.vue' // Import the TodoView component (moved)
+import PdfReader from '@/page/pdf/PdfReader.vue'
 
 export default [{
     path: '/',
@@ -37,7 +38,8 @@ export default [{
             youtube: Youtube,// Use the new component here
             youtubePlayer: YoutubePlayer, // Use the new component here
             todo: TodoView, // Add the todo component
-            aiHistory: AiCallHistory // Expose AiCallHistory as a top-level named view for the Index tab
+            aiHistory: AiCallHistory, // Expose AiCallHistory as a top-level named view for the Index tab
+            pdfReader: PdfReader
         },
         children: [{
             path: 'detail',


### PR DESCRIPTION
## Summary
- replace the manual canvas/text-layer renderer with the official pdf.js PDFViewer so the rendered text is selectable
- initialize and reuse the pdf.js viewer infrastructure, keeping the existing selection popup workflow intact
- refresh the component styles to match the new viewer structure while preserving the empty-state prompt

## Testing
- npm run lint *(fails: vue-cli-service is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690b422e24b4832db4c9fbdce6603683