### PR TITLE
Add route reinitialization helper for AI response detail

### DIFF
--- a/src/page/ai/AiResponseDetail.vue
+++ b/src/page/ai/AiResponseDetail.vue
@@ -358,6 +358,49 @@ export default {
       } catch (_) { /* ignore */ }
     },
 
+    async initializeFromRoute() {
+      // Preserve the latest route params for future navigations
+      try {
+        this.preservedQueryParams = { ...this.$route.query };
+      } catch (e) {
+        this.preservedQueryParams = {};
+      }
+
+      // Ensure any active streams are closed and stacked explanations cleared
+      this.closeWebSocket('all');
+      this.closeSelectionResponse();
+
+      // Reset per-request state
+      this.apiLoading = false;
+      this.isStreaming = false;
+      this.currentRequestId = null;
+      this.selectionDialogVisible = false;
+      this.selectionResponseVisible = false;
+      this.selectionApiLoading = false;
+      this.isSelectionStreaming = false;
+      this.selectionCurrentRequestId = null;
+      this.selectedText = '';
+      this.selectionResponseText = '';
+      this.lastSelectedText = '';
+      this.selectionSourceType = '';
+      this.selectionSourceExplanationId = '';
+      this.lastErrorMessage = '';
+      this.aiResponseVO.responseText = '';
+      this._mainWsAttempts = 0;
+      this._mainWsHadData = false;
+      this._mainFallbackInFlight = false;
+      this._lastMainRequest = null;
+
+      // Sync the selected mode from the current route
+      this.selectedMode = this.$route?.query?.selectedMode;
+
+      // Attempt to restore cached content; otherwise trigger a fresh init
+      const restored = this.tryRestoreFromCache();
+      if (!restored) {
+        await this.init();
+      }
+    },
+
     async init() {
       // Clear previous inline errors before a new session
       this.lastErrorMessage = ''


### PR DESCRIPTION
## Summary
- implement initializeFromRoute to reset AI response state on route changes
- close active websockets, preserve query params, and reload data or cached state

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ea1c465dc832da9e952871ca9ee4c)