### PR TITLE
Add website data clearing action to user center

### DIFF
--- a/src/page/user/UserCenter.vue
+++ b/src/page/user/UserCenter.vue
@@ -11,7 +11,15 @@
         </div>
       </div>
       <div class="user-actions">
-        <el-button type="info" size="small" @click="handleLoginOut" class="logout-button">
+        <el-button
+            type="warning"
+            size="small"
+            @click="handleClearWebsiteData"
+            :loading="clearingWebsiteData"
+            class="action-button clear-data-button">
+          {{ $t('audio.cleanAllCache') }}
+        </el-button>
+        <el-button type="info" size="small" @click="handleLoginOut" class="action-button logout-button">
           <i class="el-icon-switch-button"></i> {{ $t('user.loginOut') }}
         </el-button>
       </div>
@@ -306,6 +314,8 @@ import { getStore, setStore } from '@/util/store'
 import review from '@/api/review'
 import kiwiConst from '@/const/kiwiConsts'
 import util from '@/util/util'
+import msgUtil from '@/util/msg'
+import { clearWebsiteData as clearWebsiteDataUtil } from '@/util/clearWebsiteData'
 import Bgm from '@/page/bgm/Index'
 import { setLanguage as setUiLanguage } from '@/i18n'
 
@@ -346,7 +356,8 @@ export default {
       hotkeyRows: [],
 
       // NEW: Feature tabs toggle local state
-      enabledTabsLocal: { ...kiwiConst.DEFAULT_ENABLED_TABS }
+      enabledTabsLocal: { ...kiwiConst.DEFAULT_ENABLED_TABS },
+      clearingWebsiteData: false
     }
   },
 
@@ -524,6 +535,19 @@ export default {
     },
 
     // Settings methods
+    async handleClearWebsiteData() {
+      this.clearingWebsiteData = true
+      try {
+        await clearWebsiteDataUtil()
+        msgUtil.msgSuccess(this, this.$t('audio.cacheCleanedSuccess'))
+      } catch (error) {
+        console.error('Failed to clear website data:', error)
+        msgUtil.msgError(this, this.$t('messages.systemError'))
+      } finally {
+        this.clearingWebsiteData = false
+      }
+    },
+
     handleLoginOut() {
       this.$store.dispatch('LogOut').then(() => {
         this.$router.push({ path: website.noAuthPath.detail, query: { active: 'search' } })
@@ -930,12 +954,11 @@ export default {
   .user-actions {
     display: flex;
     gap: 12px;
+    align-items: center;
   }
 }
 
-/* Logout Button Styling */
-.logout-button {
-  background: linear-gradient(135deg, #909399 0%, #606266 100%) !important;
+.action-button {
   border: none !important;
   color: white !important;
   padding: 12px 20px !important;
@@ -945,10 +968,23 @@ export default {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1) !important;
 
   &:hover {
-    background: linear-gradient(135deg, #82848a 0%, #565a5f 100%) !important;
-    color: white !important;
     transform: translateY(-1px) !important;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
+  }
+
+  &:active {
+    transform: translateY(0px) !important;
+  }
+}
+
+/* Logout Button Styling */
+.logout-button {
+  @extend .action-button;
+  background: linear-gradient(135deg, #909399 0%, #606266 100%) !important;
+
+  &:hover {
+    background: linear-gradient(135deg, #82848a 0%, #565a5f 100%) !important;
+    color: white !important;
   }
 
   &:focus {
@@ -956,9 +992,21 @@ export default {
     color: white !important;
     box-shadow: 0 0 0 2px rgba(144, 147, 153, 0.3) !important;
   }
+}
 
-  &:active {
-    transform: translateY(0px) !important;
+.clear-data-button {
+  @extend .action-button;
+  background: linear-gradient(135deg, #e6a23c 0%, #f7ba2a 100%) !important;
+
+  &:hover {
+    background: linear-gradient(135deg, #d1941a 0%, #e6a621 100%) !important;
+    color: white !important;
+  }
+
+  &:focus {
+    background: linear-gradient(135deg, #d1941a 0%, #e6a621 100%) !important;
+    color: white !important;
+    box-shadow: 0 0 0 2px rgba(230, 162, 60, 0.3) !important;
   }
 }
 

--- a/src/util/clearWebsiteData.js
+++ b/src/util/clearWebsiteData.js
@@ -1,0 +1,73 @@
+export async function clearWebsiteData() {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage && window.localStorage.clear()
+  } catch (error) {
+    console.warn('Failed to clear localStorage', error)
+  }
+
+  try {
+    window.sessionStorage && window.sessionStorage.clear()
+  } catch (error) {
+    console.warn('Failed to clear sessionStorage', error)
+  }
+
+  if (typeof document !== 'undefined' && document.cookie) {
+    const cookies = document.cookie.split(';')
+    cookies.forEach(cookie => {
+      const eqPos = cookie.indexOf('=')
+      const name = eqPos > -1 ? cookie.substr(0, eqPos).trim() : cookie.trim()
+      if (name) {
+        document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`
+      }
+    })
+  }
+
+  const clearIndexedDb = async () => {
+    if (typeof indexedDB === 'undefined') {
+      return
+    }
+
+    if (typeof indexedDB.databases === 'function') {
+      try {
+        const databases = await indexedDB.databases()
+        await Promise.all(databases.map(dbInfo => {
+          if (!dbInfo || !dbInfo.name) {
+            return Promise.resolve()
+          }
+          return new Promise(resolve => {
+            const request = indexedDB.deleteDatabase(dbInfo.name)
+            request.onsuccess = request.onerror = request.onblocked = () => resolve()
+          })
+        }))
+      } catch (error) {
+        console.warn('Failed to enumerate indexedDB databases', error)
+      }
+    }
+  }
+
+  const clearCaches = () => {
+    if (typeof caches === 'undefined') {
+      return Promise.resolve()
+    }
+    return caches.keys().then(keys => Promise.all(keys.map(key => caches.delete(key)))).catch(error => {
+      console.warn('Failed to clear Cache API storage', error)
+    })
+  }
+
+  const tasks = [clearIndexedDb(), clearCaches()]
+  await Promise.all(tasks)
+
+  if (typeof navigator !== 'undefined' && navigator.serviceWorker && navigator.serviceWorker.controller) {
+    try {
+      navigator.serviceWorker.controller.postMessage({ action: 'clearCache' })
+    } catch (error) {
+      console.warn('Failed to notify service worker to clear cache', error)
+    }
+  }
+}
+
+export default clearWebsiteData


### PR DESCRIPTION
## Summary
- remove the background music management cache clearing button
- extract a reusable website data clearing utility and reuse it in the user center header
- align the logout and clear data actions with shared styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691257f74e48832da6f3bab12e598423)