### PR TITLE
Include native language in search navigation and AI caching

### DIFF
--- a/src/page/ai/AiResponseDetail.vue
+++ b/src/page/ai/AiResponseDetail.vue
@@ -292,7 +292,8 @@ export default {
       const selectedMode = (q.selectedMode || '').toString()
       const language = (q.language || '').toString()
       const originalText = (q.originalText || '').toString()
-      return `${selectedMode}|${language}|${originalText}`
+      const nativeLanguage = (q.nativeLanguage || '').toString()
+      return `${selectedMode}|${language}|${nativeLanguage}|${originalText}`
     }
   },
   watch: {
@@ -300,8 +301,18 @@ export default {
       deep: true,
       handler(newQ, oldQ) {
         try {
-          const newKey = [String(newQ.selectedMode||''), String(newQ.language||''), String(newQ.originalText||'')].join('|')
-          const oldKey = [String(oldQ && oldQ.selectedMode||''), String(oldQ && oldQ.language||''), String(oldQ && oldQ.originalText||'')].join('|')
+          const newKey = [
+            String(newQ.selectedMode || ''),
+            String(newQ.language || ''),
+            String(newQ.nativeLanguage || ''),
+            String(newQ.originalText || '')
+          ].join('|')
+          const oldKey = [
+            String(oldQ && oldQ.selectedMode || ''),
+            String(oldQ && oldQ.language || ''),
+            String(oldQ && oldQ.nativeLanguage || ''),
+            String(oldQ && oldQ.originalText || '')
+          ].join('|')
           // Ignore route churn if core inputs haven’t changed
           if (newKey === oldKey) return
           // Otherwise, re-initialize once with new core inputs
@@ -407,7 +418,10 @@ export default {
 
       let originalText = this.$route.query.originalText;
       let targetLanguage = this.$route.query.language ? this.$route.query.language : this.defaultTargetLanguage;
-      let nativeLanguage = this.defaultNativeLanguage;
+      const routeNativeLanguage = this.$route?.query?.nativeLanguage
+      let nativeLanguage = !util.isEmptyStr(routeNativeLanguage)
+        ? routeNativeLanguage
+        : this.defaultNativeLanguage;
       // Validate selected mode to avoid INVALID_PROMPT_MODE
       let selectedMode = this.validSelectedMode;
 
@@ -1219,7 +1233,8 @@ export default {
       const originalText = q.originalText
       // Validate selected mode to keep compatibility with computed validSelectedMode
       const selectedMode = q.selectedMode || this.validSelectedMode
-      const language = q.language || this.defaultTargetLanguage
+      const language = (q.language || this.defaultTargetLanguage || '').toString()
+      const nativeLanguage = (q.nativeLanguage || this.defaultNativeLanguage || '').toString()
 
       // Decode entire content (whole content)
       const decoded = (() => {
@@ -1233,7 +1248,7 @@ export default {
 
       // New cache key format: mode-targetLang-searchingContent (whole content)
       // Use a recognizable namespace prefix; URI-encode the content to keep key safe
-      const key = `aiResponseCache:${selectedMode}-${language}-${encodeURIComponent(decoded)}`
+      const key = `aiResponseCache:${selectedMode}-${language}-${nativeLanguage}-${encodeURIComponent(decoded)}`
       if (remember) {
         this.lastCacheKey = key
       }
@@ -1245,8 +1260,8 @@ export default {
       const q = query || this.$route.query || {}
       const originalText = q.originalText
       const selectedMode = q.selectedMode || this.validSelectedMode
-      const language = q.language || this.defaultTargetLanguage
-      const native = this.defaultNativeLanguage
+      const language = (q.language || this.defaultTargetLanguage || '').toString()
+      const native = (q.nativeLanguage || this.defaultNativeLanguage || '').toString()
       const decoded = (() => {
         if (!originalText) return ''
         try {

--- a/src/page/word/Search.vue
+++ b/src/page/word/Search.vue
@@ -274,6 +274,18 @@ export default {
       });
     },
 
+    getNativeLanguage() {
+      const routeNative = this.$route?.query?.nativeLanguage
+      if (!util.isEmptyStr(routeNative)) {
+        return routeNative
+      }
+      const stored = getStore({ name: kiwiConsts.CONFIG_KEY.NATIVE_LANG })
+      if (!util.isEmptyStr(stored)) {
+        return stored
+      }
+      return kiwiConsts.TRANSLATION_LANGUAGE_CODE.Simplified_Chinese
+    },
+
     navigateIfChanged(target, { ignoreKeys = ['now'] } = {}) {
       try {
         const current = { path: this.$route.path, query: { ...this.$route.query } }
@@ -302,6 +314,7 @@ export default {
           active: 'search',
           selectedMode: this.selectedMode,
           language: this.selectedLanguage,
+          nativeLanguage: this.getNativeLanguage(),
           ytbMode: this.$route.query.ytbMode ? this.$route.query.ytbMode : kiwiConsts.YTB_MODE.CHANNEL,
           originalText: this.$route.query.originalText || '',
           now: new Date().getTime()
@@ -529,6 +542,7 @@ export default {
         active: 'search',
         selectedMode: item,
         language: newLanguage,
+        nativeLanguage: this.getNativeLanguage(),
         originalText: encodedOriginalText,
         ytbMode: this.$route.query.ytbMode ? this.$route.query.ytbMode : kiwiConsts.YTB_MODE.CHANNEL
       }
@@ -549,6 +563,7 @@ export default {
           active: 'search',
           selectedMode: this.selectedMode,
           language: item,
+          nativeLanguage: this.getNativeLanguage(),
           originalText: encodeURIComponent(this.originalText),
           ytbMode: this.$route.query.ytbMode ? this.$route.query.ytbMode : kiwiConsts.YTB_MODE.CHANNEL
         }
@@ -565,6 +580,7 @@ export default {
           active: 'search',
           selectedMode: kiwiConsts.SEARCH_DEFAULT_MODE,
           originalText: '',
+          nativeLanguage: this.getNativeLanguage(),
           ytbMode: this.$route.query.ytbMode ? this.$route.query.ytbMode : kiwiConsts.YTB_MODE.CHANNEL
         }
       }
@@ -583,6 +599,7 @@ export default {
           active: 'search',
           selectedMode: kiwiConsts.SEARCH_AI_MODES.TRANSLATION_AND_EXPLANATION.value,
           language: this.selectedLanguage,
+          nativeLanguage: this.getNativeLanguage(),
           originalText: encodedOriginalText,
           ytbMode: this.$route.query.ytbMode ? this.$route.query.ytbMode : kiwiConsts.YTB_MODE.CHANNEL
         }
@@ -679,6 +696,7 @@ export default {
         originalText: encodedOriginalText,
         selectedMode: this.selectedMode,
         language: this.selectedLanguage,
+        nativeLanguage: this.getNativeLanguage(),
         ytbMode: this.$route.query.ytbMode ? this.$route.query.ytbMode : kiwiConsts.YTB_MODE.CHANNEL,
         now: new Date().getTime()
       }
@@ -699,6 +717,7 @@ export default {
         path: kiwiConsts.ROUTES.DETAIL,
         query: {
           active: 'search',
+          nativeLanguage: this.getNativeLanguage(),
           ...queryTmp
         }
       }


### PR DESCRIPTION
## Summary
- propagate the configured native language through search navigation routes, including AI history and detail views
- ensure AI response initialization and caching include the native language when computing keys and detecting route changes

## Testing
- npm run lint *(fails: vue-cli-service: not found in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912e64f2d1c832d8dcecaaee553a889)