### PR TITLE
Guard word detail init when viewing AI responses

### DIFF
--- a/src/page/word/Detail.vue
+++ b/src/page/word/Detail.vue
@@ -138,12 +138,15 @@ export default {
     shouldSkipDetailInit() {
       const currentPath = this.$route?.path
       const selectedMode = this.$route?.query?.selectedMode
+
       if (currentPath === kiwiConsts.ROUTES.AI_RESPONSE_DETAIL) {
         return true
       }
-      if (selectedMode && selectedMode !== 'detail') {
+
+      if (typeof selectedMode !== 'undefined' && selectedMode !== 'detail') {
         return true
       }
+
       return false
     },
     async initTabActivate() {
@@ -244,6 +247,9 @@ export default {
           this.total = response.data.data.total
           this.isForceRequest = false
         } else {
+          if (this.shouldSkipDetailInit()) {
+            return
+          }
           let originalText = this.$route?.query?.originalText ? decodeURIComponent(this.$route.query.originalText) : ''
           // Preserve all existing URL parameters when navigating to AI response detail
           // but ensure we use a valid AI mode instead of 'detail' mode
@@ -255,12 +261,10 @@ export default {
             originalText: encodeURI(originalText.toLowerCase()),
             now: new Date().getTime()
           }
-          if (!this.shouldSkipDetailInit()) {
-            this.$router.push({
-              path: kiwiConsts.ROUTES.AI_RESPONSE_DETAIL,
-              query: preservedQuery
-            })
-          }
+          this.$router.push({
+            path: kiwiConsts.ROUTES.AI_RESPONSE_DETAIL,
+            query: preservedQuery
+          })
         }
         this.keyword = word
       }).catch(e => {

--- a/src/page/word/Detail.vue
+++ b/src/page/word/Detail.vue
@@ -143,7 +143,7 @@ export default {
         return true
       }
 
-      if (typeof selectedMode !== 'undefined' && selectedMode !== 'detail') {
+      if (selectedMode && selectedMode !== 'detail') {
         return true
       }
 


### PR DESCRIPTION
## Summary
- guard word detail initialization logic when the AI response view is active or not in detail mode
- skip the AI response redirect fallback when the detail view is already bypassed to avoid regenerating timestamps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913dee209c8832d99cf990c08f42ade)