### PR TITLE
refactor: centralize messaging controls

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ import {i18n, setLanguage} from '@/i18n'
 // Hotkeys storage
 import {getStore} from '@/util/store'
 import kiwiConsts from '@/const/kiwiConsts'
+import messageCenter from '@/util/msg'
 
 Vue.config.devtools = true
 
@@ -262,6 +263,24 @@ Vue.use(ElementUI, {
     menuType: 'text',
     i18n: (key, value) => i18n.t(key, value)
 })
+
+// Centralise Element UI message + notification handling so every toast respects user preferences
+const wrappedMessage = (payload, overrides) => messageCenter.toast(payload, overrides)
+wrappedMessage.success = (payload, overrides) => messageCenter.success(payload, overrides)
+wrappedMessage.warning = (payload, overrides) => messageCenter.warning(payload, overrides)
+wrappedMessage.info = (payload, overrides) => messageCenter.info(payload, overrides)
+wrappedMessage.error = (payload, overrides) => messageCenter.error(payload, overrides)
+wrappedMessage.closeAll = () => messageCenter.closeMessages()
+
+const wrappedNotify = (payload, overrides) => messageCenter.popup(payload, overrides)
+wrappedNotify.success = (payload, overrides) => messageCenter.popupSuccess(payload, overrides)
+wrappedNotify.warning = (payload, overrides) => messageCenter.popupWarning(payload, overrides)
+wrappedNotify.info = (payload, overrides) => messageCenter.popupInfo(payload, overrides)
+wrappedNotify.error = (payload, overrides) => messageCenter.popupError(payload, overrides)
+wrappedNotify.closeAll = () => messageCenter.closeNotifications()
+
+Vue.prototype.$message = wrappedMessage
+Vue.prototype.$notify = wrappedNotify
 
 Vue.config.productionTip = false
 

--- a/src/page/ai/AiCallHistory.vue
+++ b/src/page/ai/AiCallHistory.vue
@@ -226,7 +226,7 @@
 
 <script>
 import kiwiConsts from "@/const/kiwiConsts";
-import { Message } from 'element-ui';
+import messageCenter from '@/util/msg';
 import { getAiCallHistory, archiveAiCallHistory, deleteAiCallHistory } from '@/api/ai'; // Removed callAiChatCompletion
 
 export default {
@@ -318,11 +318,11 @@ export default {
           console.log('Loaded AI call history successfully:', this.historyData);
         } else {
           console.error('API returned error:', response.data);
-          Message.error(response.data.msg || 'Failed to load AI call history');
+          messageCenter.error(response.data.msg || 'Failed to load AI call history');
         }
       } catch (error) {
         console.error('Error loading AI call history:', error);
-        Message.error('Failed to load AI call history: ' + (error.message || 'Unknown error'));
+        messageCenter.error('Failed to load AI call history: ' + (error.message || 'Unknown error'));
       } finally {
         this.loading = false;
       }
@@ -450,10 +450,10 @@ export default {
     copyPrompt(prompt) {
       navigator.clipboard.writeText(prompt)
           .then(() => {
-            Message.success('Prompt copied to clipboard!');
+            messageCenter.success('Prompt copied to clipboard!');
           })
           .catch(() => {
-            Message.error('Failed to copy prompt');
+            messageCenter.error('Failed to copy prompt');
           });
     },
 
@@ -469,16 +469,16 @@ export default {
       try {
         const response = await archiveAiCallHistory(id);
         if (response.data.code === 1) {
-          Message.success(response.data.data || 'Item archived successfully');
+          messageCenter.success(response.data.data || 'Item archived successfully');
           // Reload the history to reflect changes
           this.loadHistory();
         } else {
-          Message.error(response.data.msg || 'Failed to archive item');
+          messageCenter.error(response.data.msg || 'Failed to archive item');
         }
       } catch (error) {
         console.error('Archive failed:', error);
         const errorMessage = error.response?.data?.msg || 'Failed to archive item';
-        Message.error(errorMessage);
+        messageCenter.error(errorMessage);
       } finally {
         this.archivingIds = this.archivingIds.filter(i => i !== id);
       }
@@ -501,16 +501,16 @@ export default {
       try {
         const response = await deleteAiCallHistory(id);
         if (response.data.code === 1) {
-          Message.success(response.data.data || 'Item deleted successfully');
+          messageCenter.success(response.data.data || 'Item deleted successfully');
           // Reload the history to reflect changes
           this.loadHistory();
         } else {
-          Message.error(response.data.msg || 'Failed to delete item');
+          messageCenter.error(response.data.msg || 'Failed to delete item');
         }
       } catch (error) {
         console.error('Delete failed:', error);
         const errorMessage = error.response?.data?.msg || 'Failed to delete item';
-        Message.error(errorMessage);
+        messageCenter.error(errorMessage);
       } finally {
         this.deletingIds = this.deletingIds.filter(i => i !== id);
       }

--- a/src/page/word/Search.vue
+++ b/src/page/word/Search.vue
@@ -136,7 +136,7 @@ import wordSearch from '@/api/wordSearch'
 import kiwiConsts from "@/const/kiwiConsts";
 import util from '@/util/util'
 import {setStore, getStore} from "@/util/store";
-import { Notification, Message } from 'element-ui';
+import messageCenter from '@/util/msg';
 import { getLanguageForMode, getInitialSelectedLanguage } from '@/util/langUtil';
 
 const AI_MODES = Object.values(kiwiConsts.SEARCH_AI_MODES).map(mode => mode.value)
@@ -233,7 +233,12 @@ export default {
     this.setupClipboardHandling();
 
     // Do NOT bind renderer keydown listeners; global hotkeys are handled in Electron main
-    window.addEventListener('hotkeys-updated', () => Message({ message: this.$t ? this.$t('messages.operationSuccess') : 'Hotkeys updated', type: 'success', duration: 1000 }))
+    window.addEventListener('hotkeys-updated', () => {
+      messageCenter.success({
+        message: this.$t ? this.$t('messages.operationSuccess') : 'Hotkeys updated',
+        duration: 1000
+      })
+    })
   },
   beforeDestroy() {
     this.cleanupClipboardHandling();
@@ -432,18 +437,15 @@ export default {
             this.clipboardNotification.close();
           }
 
-          this.clipboardNotification = Notification({
+          this.clipboardNotification = messageCenter.popupInfo({
             title: this.$t('messages.clipboardContentDetected'),
             message: this.$t('messages.useClipboardContent', {
               text: this.copiedTextFromClipboard.substring(0, 50) + (this.copiedTextFromClipboard.length > 50 ? '...' : '')
             }),
-            position: 'top-right',
             duration: 8000,
-            showClose: true,
-            type: 'info',
             onClick: () => {
               this.showModeSelectionDialog = true;
-              this.clipboardNotification.close();
+              this.clipboardNotification && this.clipboardNotification.close();
             },
             onClose: () => {
               this.copiedTextFromClipboard = '';
@@ -641,17 +643,15 @@ export default {
             console.log('Successfully read clipboard content:', real.substring(0, 50) + '...');
 
             // Show user feedback
-            Message({
+            messageCenter.success({
               message: this.$t('messages.usingClipboardContent', { text: real.substring(0, 50) + (real.length > 50 ? '...' : '') }),
-              type: 'success',
               duration: 2000
             });
           } else {
             // No clipboard content available
             console.log('No clipboard content found');
-            Message({
+            messageCenter.warning({
               message: this.$t('messages.enterTextToSearch'),
-              type: 'warning',
               duration: 3000
             });
             return;
@@ -670,9 +670,8 @@ export default {
             errorMessage += this.$t('messages.unableToAccessClipboard');
           }
 
-          Message({
+          messageCenter.warning({
             message: errorMessage,
-            type: 'warning',
             duration: 4000
           });
           return;

--- a/src/router/axios.js
+++ b/src/router/axios.js
@@ -3,7 +3,7 @@ import {getStore} from '@/util/store'
 import NProgress from 'nprogress'
 import responseCode from '@/const/responseCode'
 import router from '@/router/router'
-import {Message} from 'element-ui'
+import messageCenter from '@/util/msg'
 import 'nprogress/nprogress.css'
 import store from '@/store'
 import axios from 'axios'
@@ -88,10 +88,8 @@ axios.interceptors.response.use(res => {
   if (String(responseCode.UNAUTHORIZED) === status) {
     if (refreshToken) {
       store.dispatch('RefreshToken').then(() => {
-        Message({
+        messageCenter.success({
           message: responseCode['autoLoginSuccess'],
-          type: 'success',
-          center: true,
           showClose: true
         })
       })
@@ -108,10 +106,8 @@ axios.interceptors.response.use(res => {
   }
 
   if (status.indexOf('2') !== 0 || (res.data && res.data.code === responseCode.ERROR)) {
-    Message({
-      message: message,
-      type: 'error',
-      center: true,
+    messageCenter.error({
+      message,
       showClose: true
     })
     return Promise.reject(new Error(message))
@@ -123,19 +119,15 @@ axios.interceptors.response.use(res => {
 
   // Handle network errors in Electron
   if (isElectron && (error && (error.code === 'ECONNREFUSED' || error.code === 'ENOTFOUND'))) {
-    Message({
+    messageCenter.error({
       message: `Unable to connect to server at ${baseUrl}. Please check if your server is running and accessible.`,
-      type: 'error',
-      center: true,
-      showClose: true,
-      duration: 5000
+      duration: 5000,
+      showClose: true
     })
     console.error('Connection error:', error && error.message, 'Server URL:', baseUrl)
   } else {
-    Message({
+    messageCenter.error({
       message: responseCode['default'],
-      type: 'error',
-      center: true,
       showClose: true
     })
   }

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -1,7 +1,6 @@
 import { getStore, setStore } from '@/util/store'
 import { loginByUsername, logout, refreshToken } from '@/api/login'
 import { encryption } from '@/util/util'
-import { Message } from 'element-ui'
 import router from '@/router/router'
 
 const user = {

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -25,6 +25,20 @@ a{
   outline: none;
 }
 
+// Centralised hooks for Element UI toast/notification styling controlled via messageCenter
+.kiwi-message-toast {
+  font-weight: 500;
+}
+
+.kiwi-message-notify {
+  font-weight: 500;
+}
+
+.kiwi-confirm-button,
+.kiwi-cancel-button {
+  font-weight: 500;
+}
+
 // AI-aligned shared container for consistent centered layout
 .ai-container {
   max-width: 980px;

--- a/src/util/msg.js
+++ b/src/util/msg.js
@@ -1,127 +1,217 @@
-import {getStore} from '@/util/store'
+import { Message as ElementMessage, Notification as ElementNotification, MessageBox } from 'element-ui'
+import { getStore } from '@/util/store'
 import kiwiConst from '@/const/kiwiConsts'
 
-const enableMsgHint = getStore({name: kiwiConst.CONFIG_KEY.ENABLE_MSG_HINT})
+const ALWAYS_VISIBLE_TYPES = new Set(['error'])
+const DEFAULT_TOAST_OPTIONS = Object.freeze({
+  center: true,
+  offset: 200,
+  duration: 3000,
+  customClass: 'kiwi-message-toast'
+})
+const DEFAULT_POPUP_OPTIONS = Object.freeze({
+  duration: 3000,
+  position: 'top-right',
+  showClose: true,
+  customClass: 'kiwi-message-notify'
+})
 
-export default {
-
-    msgWarning: (that, msg) => {
-        that.$message.warning({
-            duration: 3000,
-            center: true,
-            offset: 200,
-            message: msg
-        })
-    },
-
-    msgError: (that, msg) => {
-        that.$notify.error({
-            title: that.$t('common.error'),
-            message: msg,
-            duration: 0
-        });
-    },
-
-    msgSuccess: (that, msg, duration) => {
-        that.$message.success({
-            duration: duration ? duration : 3000,
-            center: true,
-            offset: 200,
-            message: msg
-        })
-    },
-
-    notifySuccess: (that, title, msg, duration) => {
-        if (enableMsgHint === kiwiConst.ENABLE_MSG_HINT.DISABLE) {
-            return
-        }
-
-        that.$notify({
-            title: title,
-            message: msg ? msg : that.$t('messages.dataLoadException'), // Using a generic fallback message
-            type: 'success',
-            duration: duration ? duration : 3000,
-            position: 'top-right'
-        });
-    },
-
-    operateSuccess: that => {
-        that.$message.success({
-            duration: 2000,
-            center: true,
-            offset: 200,
-            message: that.$t('messages.operationSuccess')
-        })
-    },
-
-    // Additional utility methods for common message scenarios
-    showLoginRequired: (that) => {
-        that.$message.warning({
-            duration: 3000,
-            center: true,
-            offset: 200,
-            message: that.$t('messages.loginRequired')
-        })
-    },
-
-    showSystemError: (that) => {
-        that.$notify.error({
-            title: that.$t('common.error'),
-            message: that.$t('messages.systemError'),
-            duration: 0
-        });
-    },
-
-    showOperationTooFrequent: (that) => {
-        that.$message.warning({
-            duration: 3000,
-            center: true,
-            offset: 200,
-            message: that.$t('messages.operationTooFrequent')
-        })
-    },
-
-    showNoPermission: (that) => {
-        that.$message.warning({
-            duration: 3000,
-            center: true,
-            offset: 200,
-            message: that.$t('messages.noPermission')
-        })
-    },
-
-    showResourceNotFound: (that) => {
-        that.$message.warning({
-            duration: 3000,
-            center: true,
-            offset: 200,
-            message: that.$t('messages.resourceNotFound')
-        })
-    },
-
-    // Confirmation dialogs
-    confirmDelete: (that, callback) => {
-        that.$confirm(that.$t('messages.confirmDelete'), that.$t('collections.deleteOperation'), {
-            confirmButtonText: that.$t('common.confirm'),
-            cancelButtonText: that.$t('common.cancel'),
-            type: 'warning'
-        }).then(() => {
-            callback && callback();
-        }).catch(() => {
-            // User cancelled
-        });
-    },
-
-    confirmClear: (that, callback) => {
-        that.$confirm(that.$t('messages.confirmClear'), that.$t('messages.clearOperation'), {
-            confirmButtonText: that.$t('common.confirm'),
-            cancelButtonText: that.$t('common.cancel'),
-            type: 'warning'
-        }).then(() => {
-            callback && callback();
-        }).catch(() => {
-            // User cancelled
-        });
-    }
-
+function isMessageHintsEnabled () {
+  const preference = getStore({ name: kiwiConst.CONFIG_KEY.ENABLE_MSG_HINT })
+  return preference !== kiwiConst.ENABLE_MSG_HINT.DISABLE
 }
+
+function shouldDisplay (type, { force } = {}) {
+  if (force) return true
+  if (ALWAYS_VISIBLE_TYPES.has(type)) return true
+  return isMessageHintsEnabled()
+}
+
+function normalizeOptions (payload, overrides = {}) {
+  let base = {}
+  if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    base = { ...payload }
+  } else if (payload !== undefined) {
+    base = { message: payload }
+  }
+  return { ...base, ...overrides }
+}
+
+function extractContext (options) {
+  if (!options) return { options, context: null }
+  const { context, ...rest } = options
+  return { options: rest, context: context || null }
+}
+
+function resolveTitle (context, fallback) {
+  if (context && typeof context.$t === 'function') {
+    try { return context.$t(fallback) } catch (e) { /* ignore */ }
+  }
+  return fallback
+}
+
+function showToast (payload, overrides = {}) {
+  const normalized = normalizeOptions(payload, overrides)
+  const { options } = extractContext(normalized)
+  const { force } = options
+  const type = options.type || overrides.type || 'info'
+
+  if (!shouldDisplay(type, { force })) return null
+
+  const finalOptions = { ...DEFAULT_TOAST_OPTIONS, ...options, type }
+  delete finalOptions.force
+
+  return ElementMessage(finalOptions)
+}
+
+function showPopup (payload, overrides = {}) {
+  const normalized = normalizeOptions(payload, overrides)
+  const { options } = extractContext(normalized)
+  const { force } = options
+  const type = options.type || overrides.type || 'info'
+
+  if (!shouldDisplay(type, { force })) return null
+
+  const finalOptions = { ...DEFAULT_POPUP_OPTIONS, ...options, type }
+
+  if (type === 'error' && typeof finalOptions.duration === 'undefined') {
+    finalOptions.duration = 0
+  }
+
+  delete finalOptions.force
+
+  return ElementNotification(finalOptions)
+}
+
+function showConfirm (message, title, options) {
+  let finalMessage = message
+  let finalTitle = title
+  let finalOptions = options || {}
+
+  if (typeof title === 'object' && title !== null) {
+    finalOptions = title
+    finalTitle = title && title.title ? title.title : undefined
+  }
+
+  const mergedOptions = {
+    confirmButtonClass: 'kiwi-confirm-button',
+    cancelButtonClass: 'kiwi-cancel-button',
+    ...finalOptions
+  }
+
+  return MessageBox.confirm(finalMessage, finalTitle, mergedOptions)
+}
+
+const messageCenter = {
+  toast: showToast,
+  popup: showPopup,
+  success (payload, overrides = {}) {
+    return showToast(payload, { ...overrides, type: 'success' })
+  },
+  warning (payload, overrides = {}) {
+    return showToast(payload, { ...overrides, type: 'warning' })
+  },
+  info (payload, overrides = {}) {
+    return showToast(payload, { ...overrides, type: 'info' })
+  },
+  error (payload, overrides = {}) {
+    return showToast(payload, { ...overrides, type: 'error', force: true })
+  },
+  popupSuccess (payload, overrides = {}) {
+    return showPopup(payload, { ...overrides, type: 'success' })
+  },
+  popupWarning (payload, overrides = {}) {
+    return showPopup(payload, { ...overrides, type: 'warning' })
+  },
+  popupInfo (payload, overrides = {}) {
+    return showPopup(payload, { ...overrides, type: 'info' })
+  },
+  popupError (payload, overrides = {}) {
+    return showPopup(payload, { ...overrides, type: 'error', force: true })
+  },
+  closeMessages () {
+    if (typeof ElementMessage.closeAll === 'function') {
+      ElementMessage.closeAll()
+    }
+  },
+  closeNotifications () {
+    if (typeof ElementNotification.closeAll === 'function') {
+      ElementNotification.closeAll()
+    }
+  },
+  closeAll () {
+    this.closeMessages()
+    this.closeNotifications()
+  },
+  confirm: showConfirm,
+  isMessageHintsEnabled,
+  // Compatibility helpers used across the codebase
+  msgWarning (context, msg, overrides = {}) {
+    return showToast(msg, { ...overrides, type: 'warning', context })
+  },
+  msgError (context, msg, overrides = {}) {
+    const title = resolveTitle(context, 'common.error')
+    const localizedTitle = title && title !== 'common.error' ? title : 'Error'
+    return showPopup({ title: localizedTitle, message: msg }, { ...overrides, type: 'error', context, force: true })
+  },
+  msgSuccess (context, msg, duration) {
+    const extra = {}
+    if (typeof duration !== 'undefined') extra.duration = duration
+    return showToast(msg, { context, type: 'success', ...extra })
+  },
+  notifySuccess (context, title, msg, duration) {
+    const fallback = context && context.$t ? context.$t('messages.dataLoadException') : 'Operation completed'
+    const extra = {}
+    if (typeof duration !== 'undefined') extra.duration = duration
+    return showPopup({ title, message: msg || fallback }, { context, type: 'success', ...extra })
+  },
+  operateSuccess (context) {
+    const message = context && context.$t ? context.$t('messages.operationSuccess') : 'Operation succeeded'
+    return showToast(message, { context, type: 'success', duration: 2000 })
+  },
+  showLoginRequired (context) {
+    const message = context && context.$t ? context.$t('messages.loginRequired') : 'Login required'
+    return showToast(message, { context, type: 'warning' })
+  },
+  showSystemError (context) {
+    const title = context && context.$t ? context.$t('common.error') : 'Error'
+    const message = context && context.$t ? context.$t('messages.systemError') : 'System error'
+    return showPopup({ title, message }, { context, type: 'error', force: true })
+  },
+  showOperationTooFrequent (context) {
+    const message = context && context.$t ? context.$t('messages.operationTooFrequent') : 'Operation too frequent'
+    return showToast(message, { context, type: 'warning' })
+  },
+  showNoPermission (context) {
+    const message = context && context.$t ? context.$t('messages.noPermission') : 'No permission'
+    return showToast(message, { context, type: 'warning' })
+  },
+  showResourceNotFound (context) {
+    const message = context && context.$t ? context.$t('messages.resourceNotFound') : 'Resource not found'
+    return showToast(message, { context, type: 'warning' })
+  },
+  confirmDelete (context, callback) {
+    const message = context && context.$t ? context.$t('messages.confirmDelete') : 'Delete this item?'
+    const title = context && context.$t ? context.$t('collections.deleteOperation') : 'Delete'
+    return showConfirm(message, title, {
+      confirmButtonText: context && context.$t ? context.$t('common.confirm') : 'Confirm',
+      cancelButtonText: context && context.$t ? context.$t('common.cancel') : 'Cancel',
+      type: 'warning'
+    }).then(() => {
+      if (typeof callback === 'function') callback()
+    }).catch(() => {})
+  },
+  confirmClear (context, callback) {
+    const message = context && context.$t ? context.$t('messages.confirmClear') : 'Clear all items?'
+    const title = context && context.$t ? context.$t('messages.clearOperation') : 'Clear'
+    return showConfirm(message, title, {
+      confirmButtonText: context && context.$t ? context.$t('common.confirm') : 'Confirm',
+      cancelButtonText: context && context.$t ? context.$t('common.cancel') : 'Cancel',
+      type: 'warning'
+    }).then(() => {
+      if (typeof callback === 'function') callback()
+    }).catch(() => {})
+  }
+}
+
+export default messageCenter

--- a/src/util/oauth.js
+++ b/src/util/oauth.js
@@ -1,6 +1,6 @@
 // src/util/oauth.js - Enhanced OAuth utility for mobile compatibility
 import {getStore, setStore} from '@/util/store'
-import {Message} from 'element-ui'
+import messageCenter from '@/util/msg'
 
 // Flag to prevent multiple OAuth processing
 let isProcessingOAuth = false
@@ -52,12 +52,10 @@ export const handleGoogleOAuthCallback = () => {
 
     if (error) {
         console.error(' [OAUTH] Google OAuth error:', error)
-        Message({
+        messageCenter.error({
             message: `Login failed: ${error}`,
-            type: 'error',
-            center: true,
-            showClose: true,
-            duration: 5000
+            duration: 5000,
+            showClose: true
         })
         return false
     }
@@ -108,10 +106,8 @@ export const handleGoogleOAuthCallback = () => {
             window.location.href = window.location.origin + window.location.pathname
 
             console.log(' [OAUTH] Showing success message')
-            Message({
+            messageCenter.success({
                 message: `Welcome back, ${decodedUser}!`,
-                type: 'success',
-                center: true,
                 duration: 3000
             })
 
@@ -127,10 +123,8 @@ export const handleGoogleOAuthCallback = () => {
             console.error(' [OAUTH] Error during OAuth processing:', error)
             isProcessingOAuth = false
 
-            Message({
+            messageCenter.error({
                 message: 'Login processing failed. Please try again.',
-                type: 'error',
-                center: true,
                 duration: 5000
             })
 


### PR DESCRIPTION
## Summary
- route all message, notification, and confirmation flows through a centralized `messageCenter` helper that honors the user hint toggle while always surfacing errors
- wrap Element UI `$message`/`$notify` APIs with the new helper and update OAuth, axios, AI history, and search clipboard flows to use the shared utility
- add lightweight styling hooks for consistent toast/notification presentation across the app

## Testing
- npm run lint *(fails: `vue-cli-service` missing because dependencies could not be installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691427f71710832db6fcdc8392d567a4)