### PR TITLE
Fix AI selection popup stream cleanup and revert search styling overrides

### DIFF
--- a/src/page/ai/AiSelectionPopup.vue
+++ b/src/page/ai/AiSelectionPopup.vue
@@ -393,6 +393,14 @@ export default {
       msgUtil.msgError(this, this.aiLastError)
     },
 
+    stopStream(silent) {
+      try { this.aiWebsocket && this.aiWebsocket.close() } catch (_) {}
+      this.aiWebsocket = null
+      this.aiSearchLoading = false
+      this.aiIsStreaming = false
+      if (!silent) this.aiLastError = ''
+    },
+
     // Utils
     generateRequestId() { return 'req_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9) },
     sanitizePotentialJsonString(str) {

--- a/src/page/word/Search.vue
+++ b/src/page/word/Search.vue
@@ -7,7 +7,6 @@
             ref="auto"
             :type="getInputType"
             v-model="originalText"
-            :style="{width: searchInputWidth}"
             :fetch-suggestions="querySearch"
             :placeholder="$t('searchPlaceholders.dictionary')"
             size="mini"
@@ -151,7 +150,6 @@ export default {
   data() {
     return {
       originalText: this.$route.query.originalText ? decodeURIComponent(this.$route.query.originalText.trim()) : '',
-      searchInputWidth: document.body.clientWidth / 1.3 + 'px',
       lazy: this.$route.path.indexOf('lazy') > -1,
       selectedMode: this.$route.query.selectedMode ? decodeURIComponent(this.$route.query.selectedMode) : kiwiConsts.SEARCH_DEFAULT_MODE,
       searchModes: Object.values(kiwiConsts.SEARCH_MODES_DATA).map(mode => ({
@@ -788,30 +786,6 @@ export default {
 /* .ai-mode-text ::v-deep(.el-input__inner) {
   color: #ffffff !important;
 } */
-
-/* Mobile-specific styles */
-@media (max-width: 768px) {
-  .el-row {
-    margin-bottom: 8px;
-  }
-
-  .el-dialog {
-    width: 95% !important;
-  }
-
-  /* Responsive select widths - only applied on mobile screens */
-  .mode-select {
-    width: 50% !important;
-  }
-
-  .language-select {
-    width: 40% !important;
-  }
-
-  .language-switcher {
-    margin-right: 5px;
-  }
-}
 
 /* Clipboard info dialog styles */
 .el-dialog ol {


### PR DESCRIPTION
## Summary
- add a reusable stopStream helper so the selection popup can reliably close its primary WebSocket stream
- remove the custom width binding and mobile-specific CSS overrides for the search input to restore Element UI defaults

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914fa50abe8832daa9398c7e219aabd)